### PR TITLE
Add support for HS105 and power strips

### DIFF
--- a/src/devices.rs
+++ b/src/devices.rs
@@ -118,6 +118,10 @@ new_device!(HS100, "smart plug");
 
 impl<T: Protocol> Switch for HS100<T> {}
 
+new_device!(HS105, "smart plug mini");
+
+impl<T: Protocol> Switch for HS105<T> {}
+
 new_device!(HS110, "smart plug with energy monitoring");
 
 impl<T: Protocol> Switch for HS110<T> {}
@@ -156,6 +160,8 @@ impl<T: Protocol> Emeter for LB110<T> {
 pub enum Device {
     /// Device variant for an HS100 smart plug
     HS100(HS100<DefaultProtocol>),
+    /// Device variant for an HS105 smart plug
+    HS105(HS105<DefaultProtocol>),
     /// Device variant for an HS110 smart plug
     HS110(HS110<DefaultProtocol>),
     /// Device variant for an LB110 smart light
@@ -171,6 +177,8 @@ impl Device {
         let model = &device_data.sysinfo().model;
         if model.contains("HS100") {
             Device::HS100(HS100::from_addr(addr))
+        } else if model.contains("HS105") {
+            Device::HS105(HS105::from_addr(addr))
         } else if model.contains("HS110") {
             Device::HS110(HS110::from_addr(addr))
         } else if model.contains("LB110") {
@@ -185,6 +193,7 @@ impl DeviceActions for Device {
     fn send<D: DeserializeOwned>(&self, msg: &str) -> Result<D> {
         match self {
             Device::HS100(d) => d.send(msg),
+            Device::HS105(d) => d.send(msg),
             Device::HS110(d) => d.send(msg),
             Device::LB110(d) => d.send(msg),
             Device::Unknown(d) => d.send(msg),

--- a/src/devices.rs
+++ b/src/devices.rs
@@ -23,7 +23,7 @@ use std::{
 use serde::de::DeserializeOwned;
 
 use crate::{
-    capabilities::{DeviceActions, Dimmer, Emeter, Light, Switch},
+    capabilities::{DeviceActions, Dimmer, Emeter, Light, Switch, MultiSwitch},
     datatypes::DeviceData,
     error::Result,
     protocol::{DefaultProtocol, Protocol},
@@ -129,7 +129,7 @@ impl<T: Protocol> Emeter for HS110<T> {}
 
 new_device!(HS300, "smart power strip with energy monitoring");
 
-impl<T: Protocol> Switch for HS300<T> {}
+impl<T: Protocol> MultiSwitch for HS300<T> {}
 impl<T: Protocol> Emeter for HS300<T> {}
 
 new_device!(LB110, "dimmable smart lightbulb");

--- a/src/devices.rs
+++ b/src/devices.rs
@@ -127,6 +127,11 @@ new_device!(HS110, "smart plug with energy monitoring");
 impl<T: Protocol> Switch for HS110<T> {}
 impl<T: Protocol> Emeter for HS110<T> {}
 
+new_device!(HS300, "smart power strip with energy monitoring");
+
+impl<T: Protocol> Switch for HS300<T> {}
+impl<T: Protocol> Emeter for HS300<T> {}
+
 new_device!(LB110, "dimmable smart lightbulb");
 
 impl<T: Protocol> Switch for LB110<T> {
@@ -164,6 +169,8 @@ pub enum Device {
     HS105(HS105<DefaultProtocol>),
     /// Device variant for an HS110 smart plug
     HS110(HS110<DefaultProtocol>),
+    /// Device variant for an HS300 smart power strip
+    HS300(HS300<DefaultProtocol>),
     /// Device variant for an LB110 smart light
     LB110(LB110<DefaultProtocol>),
     /// Device variant for an unknown device
@@ -181,6 +188,8 @@ impl Device {
             Device::HS105(HS105::from_addr(addr))
         } else if model.contains("HS110") {
             Device::HS110(HS110::from_addr(addr))
+        } else if model.contains("HS300") {
+            Device::HS300(HS300::from_addr(addr))
         } else if model.contains("LB110") {
             Device::LB110(LB110::from_addr(addr))
         } else {
@@ -195,6 +204,7 @@ impl DeviceActions for Device {
             Device::HS100(d) => d.send(msg),
             Device::HS105(d) => d.send(msg),
             Device::HS110(d) => d.send(msg),
+            Device::HS300(d) => d.send(msg),
             Device::LB110(d) => d.send(msg),
             Device::Unknown(d) => d.send(msg),
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use serde_json::{json, to_string as stringify, Value};
 use tplinker::{
     capabilities::{DeviceActions, Switch},
     datatypes::{DeviceData, SysInfo},
-    devices::{Device, RawDevice, HS100, HS105, HS110, LB110},
+    devices::{Device, RawDevice, HS100, HS105, HS110, HS300, LB110},
     error::Result as TpResult,
 };
 
@@ -384,6 +384,7 @@ impl Format {
             Device::HS100(_) => "HS100",
             Device::HS105(_) => "HS105",
             Device::HS110(_) => "HS110",
+            Device::HS300(_) => "HS300",
             Device::LB110(_) => "LB110",
             Device::Unknown(_) => "unknown",
         }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,7 +6,7 @@ use serde_json::{json, to_string as stringify, Value};
 use tplinker::{
     capabilities::{DeviceActions, Switch},
     datatypes::{DeviceData, SysInfo},
-    devices::{Device, RawDevice, HS100, HS110, LB110},
+    devices::{Device, RawDevice, HS100, HS105, HS110, LB110},
     error::Result as TpResult,
 };
 
@@ -97,6 +97,7 @@ fn command_switch_toggle(addr: SocketAddr, state: &str, format: Format) -> Vec<V
             } else {
                 match &dev {
                     Device::HS100(s) => toggle_switch(s, state),
+                    Device::HS105(s) => toggle_switch(s, state),
                     Device::HS110(s) => toggle_switch(s, state),
                     Device::LB110(s) => toggle_switch(s, state),
                     _ => panic!("not a switchable device: {}", addr),
@@ -131,6 +132,10 @@ fn device_from_addr(addr: SocketAddr) -> TpResult<(SocketAddr, Device, SysInfo)>
         let dev = HS100::from_raw(raw);
         let info = dev.sysinfo()?;
         (Device::HS100(dev), info)
+    } else if info.model.starts_with("HS105") {
+        let dev = HS105::from_raw(raw);
+        let info = dev.sysinfo()?;
+        (Device::HS105(dev), info)
     } else if info.model.starts_with("HS110") {
         let dev = HS110::from_raw(raw);
         let info = dev.sysinfo()?;
@@ -154,6 +159,7 @@ fn pad(value: &str, padding: usize) -> String {
 fn device_is_on(device: &Device) -> Option<bool> {
     match device {
         Device::HS100(device) => device.is_on().ok(),
+        Device::HS105(device) => device.is_on().ok(),
         Device::HS110(device) => device.is_on().ok(),
         Device::LB110(device) => device.is_on().ok(),
         _ => None,
@@ -376,6 +382,7 @@ impl Format {
     fn device(device: Device) -> &'static str {
         match device {
             Device::HS100(_) => "HS100",
+            Device::HS105(_) => "HS105",
             Device::HS110(_) => "HS110",
             Device::LB110(_) => "LB110",
             Device::Unknown(_) => "unknown",

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ use clap::{App, AppSettings, Arg, SubCommand};
 use serde_json::{json, to_string as stringify, Value};
 
 use tplinker::{
-    capabilities::{DeviceActions, Switch},
+    capabilities::{DeviceActions, Switch, MultiSwitch},
     datatypes::{DeviceData, SysInfo},
     devices::{Device, RawDevice, HS100, HS105, HS110, HS300, LB110},
     error::Result as TpResult,
@@ -76,7 +76,7 @@ fn command_set_alias(addr: SocketAddr, alias: &str, format: Format) -> Vec<Value
         })
 }
 
-fn command_switch_toggle(addr: SocketAddr, state: &str, format: Format) -> Vec<Value> {
+fn command_switch_toggle(addr: SocketAddr, state: &str, index: Option<usize>, format: Format) -> Vec<Value> {
     let (expected, statename) = match state {
         "toggle" => (None, "Toggled"),
         "on" => (Some(true), "Switched on"),
@@ -86,7 +86,7 @@ fn command_switch_toggle(addr: SocketAddr, state: &str, format: Format) -> Vec<V
 
     device_from_addr(addr)
         .and_then(|(addr, dev, _info)| {
-            let actual = device_is_on(&dev).unwrap();
+            let actual = device_is_on(&dev, index).unwrap();
             let expected = match expected {
                 None => !actual,
                 Some(e) => e,
@@ -99,13 +99,14 @@ fn command_switch_toggle(addr: SocketAddr, state: &str, format: Format) -> Vec<V
                     Device::HS100(s) => toggle_switch(s, state),
                     Device::HS105(s) => toggle_switch(s, state),
                     Device::HS110(s) => toggle_switch(s, state),
+                    Device::HS300(s) if index.is_some() => toggle_multiswitch(s, state, index.unwrap()),
                     Device::LB110(s) => toggle_switch(s, state),
                     _ => panic!("not a switchable device: {}", addr),
                 }
                 .map(|_| Value::Bool(true))
                 .unwrap_or_else(|err| {
                     // In case it errors but has actually succeeded
-                    let current = device_is_on(&dev).unwrap();
+                    let current = device_is_on(&dev, index).unwrap();
                     if expected == current {
                         Value::Bool(true)
                     } else {
@@ -140,6 +141,10 @@ fn device_from_addr(addr: SocketAddr) -> TpResult<(SocketAddr, Device, SysInfo)>
         let dev = HS110::from_raw(raw);
         let info = dev.sysinfo()?;
         (Device::HS110(dev), info)
+    } else if info.model.starts_with("HS300") {
+        let dev = HS300::from_raw(raw);
+        let info = dev.sysinfo()?;
+        (Device::HS300(dev), info)
     } else if info.model.starts_with("LB110") {
         let dev = LB110::from_raw(raw);
         let info = dev.sysinfo()?;
@@ -156,11 +161,12 @@ fn pad(value: &str, padding: usize) -> String {
     format!("{}{}", value, pad)
 }
 
-fn device_is_on(device: &Device) -> Option<bool> {
+fn device_is_on(device: &Device, index: Option<usize>) -> Option<bool> {
     match device {
         Device::HS100(device) => device.is_on().ok(),
         Device::HS105(device) => device.is_on().ok(),
         Device::HS110(device) => device.is_on().ok(),
+        Device::HS300(device) if index.is_some() => device.is_on(index.unwrap()).ok(),
         Device::LB110(device) => device.is_on().ok(),
         _ => None,
     }
@@ -171,6 +177,15 @@ fn toggle_switch<S: Switch>(switch: &S, state: &str) -> TpResult<bool> {
         "on" => switch.switch_on().and(Ok(true)),
         "off" => switch.switch_off().and(Ok(false)),
         "toggle" => switch.toggle(),
+        _ => unreachable!(),
+    }
+}
+
+fn toggle_multiswitch<S: MultiSwitch>(switch: &S, state: &str, index: usize) -> TpResult<bool> {
+    match state {
+        "on" => switch.switch_on(index).and(Ok(true)),
+        "off" => switch.switch_off(index).and(Ok(false)),
+        "toggle" => switch.toggle(index),
         _ => unreachable!(),
     }
 }
@@ -301,7 +316,7 @@ impl Format {
                 ["Product", sysinfo.dev_name],
                 ["Model", sysinfo.model],
                 ["Signal", format!("{} dB", sysinfo.rssi)],
-                ["On?", device_is_on(&device)],
+                ["On?", device_is_on(&device, None)],
             ]),
             Format::Long => {
                 let (lat, lon) = device
@@ -321,7 +336,7 @@ impl Format {
                     ["Latitude", lat],
                     ["Longitude", lon],
                     ["Mode", sysinfo.active_mode],
-                    ["On?", device_is_on(&device)],
+                    ["On?", device_is_on(&device, None)],
                 ])
             }
             Format::JSON => {
@@ -452,6 +467,11 @@ fn main() {
                         .possible_values(&["on", "off", "toggle"])
                         .default_value("toggle")
                         .required(true),
+                )
+                .arg(
+                    Arg::with_name("index")
+                        .default_value("0")
+                        .required(false),
                 ),
         )
         .get_matches();
@@ -511,7 +531,8 @@ fn main() {
         ("switch", Some(matches)) => {
             let address = parse_address(matches.value_of("address").unwrap());
             let state = matches.value_of("state").unwrap();
-            command_switch_toggle(address, state, format)
+            let index = matches.value_of("index").and_then(|index| index.parse::<usize>().ok());
+            command_switch_toggle(address, state, index, format)
         }
         _ => unreachable!(),
     })


### PR DESCRIPTION
Added support for the HS105 (Smart Wi-Fi Plug Mini) which operates the same exact way as the HS100.

Also added support for the HS300 power strip with 6 outlets. To do this, I created a `MultiSwitch` capability trait that supports a 0-based index into the outlets on the strip. This should lay the groundwork to quickly get other multi-power outlet Kasa devices working easily, but I don't have other devices to test with currently.

Finally, I updated the CLI to take an optional `index` argument for the `switch` command which can be used to turn individual power strip outlets on or off.