### PR TITLE
Update type in README example

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,7 +60,7 @@ use tplinker::{
 };
 
 let device = LB110::new("192.168.0.99:9999").unwrap();
-if device.is_on().unrwap() {
+if device.is_on().unwrap() {
   let brightness = device.brightness().unwrap();
   if brightness < 50 {
     device.set_brightness(brightness + 20).unwrap();


### PR DESCRIPTION
### What's Changed

A fix for a typo in the `Direct device` example contained within the README. 

When copying and running the example (replacing the ip:port with a device on the network) - it produces the following error due to the typo in `unwrap()`.

```rust
 if device.is_on().unrwap() {
                   ^^^^^^ help: there is a method with a similar name: `unwrap`
```